### PR TITLE
Fix calculateScore and ValidTurn

### DIFF
--- a/Assets/Classes/Scrabble.cs
+++ b/Assets/Classes/Scrabble.cs
@@ -64,6 +64,10 @@ namespace ScrabbleNamespace
         //returns: an integer totaling the spaces played, as well as all the confirmed viable Tiles up, down, left and right of each of those spaces played
         public static int calculateScore(List<BoardSpace> spacesPlayed)
         {
+            if(spacesPlayed.Count == 0)
+            {
+                return 0;
+            }
             int total = 0;
             int wordTotal = 0;
             string modifiers = "";
@@ -334,8 +338,12 @@ namespace ScrabbleNamespace
                 string reverse = reverseWord(wordToCheck);
                 if (!oSpell.TestWord(reverse) && !oSpell.TestWord(wordToCheck))
                 {
-                    //FAKE WORD DETECTED - RETURN FALSE AND NOTIFY PLAYER THEIR TURN IS NO GOOD
-                    return false;
+                    //Allows no tiles to be played and still be a valid turn
+                    if(spacesPlayed.Count != 0)
+                    {
+                        //FAKE WORD DETECTED - RETURN FALSE AND NOTIFY PLAYER THEIR TURN IS NO GOOD
+                        return false;
+                    }                   
                 }
             }
 


### PR DESCRIPTION
Allows these two methods to allow spacesPlayed to be zero and still submit. validTurn will return true in this instance, and calculate score will return zero